### PR TITLE
Disambiguate types for processing 2 / java 7

### DIFF
--- a/processing_apps/BlinkMSequencer2/BlinkMSequencer2.pde
+++ b/processing_apps/BlinkMSequencer2/BlinkMSequencer2.pde
@@ -36,13 +36,25 @@
 
 
 import java.awt.*;
-import java.awt.event.*;
 
-import javax.swing.*;
-import javax.swing.event.*;
-import javax.swing.colorchooser.*;
-import javax.swing.plaf.metal.*;
-import java.util.jar.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.event.MouseMotionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+
+import java.util.HashSet;
+
+import javax.swing.plaf.metal.MetalLookAndFeel;
+import javax.swing.plaf.metal.DefaultMetalTheme;
+import javax.swing.UIManager;
 
 import thingm.linkm.*;
 


### PR DESCRIPTION
When running this project with processing2/3 and java7, there is some ambiguity between the types processing.event.MouseEvent and java.awt.event.MouseEvent, and potentially others. java.util.HashSet was also reported as missing. Removes unused imports.
